### PR TITLE
feat(benchmark): AUPR acceptance gate to block a regressing index refresh

### DIFF
--- a/workflows/short-read-mngs/auto_benchmark/harvest.py
+++ b/workflows/short-read-mngs/auto_benchmark/harvest.py
@@ -42,12 +42,34 @@ def main():
     parser.add_argument(
         "--taxadb", metavar="FILENAME", type=str, help="taxadb SQLite file, if available"
     )
+    parser.add_argument(
+        "--min-aupr",
+        metavar="FLOAT",
+        type=float,
+        default=None,
+        help="AUPR acceptance gate: exit non-zero if any sample's NT_aupr/NR_aupr is below this "
+        "floor (e.g. 0.98). Omit for report-only. Used to BLOCK a taxonomy/index refresh whose "
+        "candidate index regresses classification accuracy vs the truth set.",
+    )
 
     args = parser.parse_args(sys.argv[1:])
     harvest(**vars(args))
 
 
-def harvest(outputs, taxadb):
+def aupr_regressions(results, min_aupr):
+    """Pure gate check: return [(sample, metric, value), ...] for every *_aupr metric below the
+    floor. Ignores non-metric keys (e.g. the raw 'outputs' blob) and non-numeric values."""
+    regressions = []
+    for sample, metrics in results.items():
+        if not isinstance(metrics, dict):
+            continue
+        for key, value in metrics.items():
+            if key.endswith("_aupr") and isinstance(value, (int, float)) and value < min_aupr:
+                regressions.append((sample, key, value))
+    return regressions
+
+
+def harvest(outputs, taxadb, min_aupr=None):
     queue = []
 
     # process command line args
@@ -83,6 +105,20 @@ def harvest(outputs, taxadb):
         rslt[sample]["outputs"] = outputs_json
 
     print(json.dumps(rslt, indent=2))
+
+    # AUPR acceptance gate (opt-in). Blocks a taxonomy/index refresh whose candidate index regresses
+    # classification accuracy below the floor vs the truth set. Report-only when --min-aupr is unset.
+    if min_aupr is not None:
+        regressions = aupr_regressions(rslt, min_aupr)
+        if regressions:
+            print(
+                f"\nAUPR GATE FAILED: {len(regressions)} metric(s) below {min_aupr}:",
+                file=sys.stderr,
+            )
+            for sample, metric, value in sorted(regressions):
+                print(f"  {sample} {metric} = {value:.4f} < {min_aupr}", file=sys.stderr)
+            sys.exit(1)
+        print(f"\nAUPR gate PASSED: all NT/NR AUPR >= {min_aupr}", file=sys.stderr)
 
 
 def harvest_sample(sample, outputs_json, taxadb):

--- a/workflows/short-read-mngs/auto_benchmark/test_harvest_aupr_gate.py
+++ b/workflows/short-read-mngs/auto_benchmark/test_harvest_aupr_gate.py
@@ -1,0 +1,49 @@
+"""Unit tests for the AUPR acceptance gate in harvest.py (aupr_regressions).
+
+Kept dependency-light: exercises only the pure gate function, which decides whether a benchmark run's
+per-sample NT/NR AUPR clears the floor used to BLOCK a regressing taxonomy/index refresh.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from harvest import aupr_regressions  # noqa: E402
+
+
+def test_passes_when_all_metrics_clear_the_floor():
+    results = {
+        "atcc_even": {"NT_aupr": 0.995, "NR_aupr": 0.991, "outputs": {"junk": 1}},
+        "atcc_staggered": {"NT_aupr": 0.982, "NR_aupr": 0.980},
+    }
+    assert aupr_regressions(results, 0.98) == []
+
+
+def test_flags_every_metric_below_the_floor():
+    results = {
+        "atcc_even": {"NT_aupr": 0.995, "NR_aupr": 0.970},   # NR regresses
+        "atcc_staggered": {"NT_aupr": 0.950, "NR_aupr": 0.999},  # NT regresses
+    }
+    regressions = aupr_regressions(results, 0.98)
+    assert ("atcc_even", "NR_aupr", 0.970) in regressions
+    assert ("atcc_staggered", "NT_aupr", 0.950) in regressions
+    assert len(regressions) == 2
+
+
+def test_ignores_non_metric_keys_and_non_numeric_values():
+    results = {
+        "s1": {"NT_aupr": 0.99, "NR_aupr": 0.99, "outputs": {"a": 0.0}, "NT_precision": [0.1, 0.2]},
+    }
+    # 'outputs' and the *_precision list must not be treated as AUPR metrics.
+    assert aupr_regressions(results, 0.98) == []
+
+
+def test_boundary_is_inclusive():
+    # exactly at the floor passes (>= floor)
+    assert aupr_regressions({"s1": {"NT_aupr": 0.98}}, 0.98) == []
+    assert aupr_regressions({"s1": {"NT_aupr": 0.9799}}, 0.98) == [("s1", "NT_aupr", 0.9799)]
+
+
+def test_tolerates_a_sample_without_metrics():
+    assert aupr_regressions({"s1": "skipped"}, 0.98) == []


### PR DESCRIPTION
The short-read-mngs benchmark computes per-sample `NT_aupr`/`NR_aupr` but **never enforced a floor** — it reported accuracy without failing on a regression. This adds the blocking gate the taxonomy refresh (#548) needs.

- `harvest.py` gains opt-in **`--min-aupr FLOAT`**. Unset → unchanged (report-only). Set (e.g. `--min-aupr 0.98`) → exits non-zero and prints exactly which `sample+metric` regressed if any NT/NR AUPR is below the floor.
- Decision is a pure function `aupr_regressions()`, **unit-tested** (`test_harvest_aupr_gate.py`: pass / fail / boundary-inclusive; ignores the non-metric `outputs` blob + `*_precision` lists + metric-less samples).

## Use as the biological gate
Run the benchmark against the candidate AlignmentConfig, then `harvest.py … --min-aupr 0.98` → blocks a candidate index that degrades classification vs the truth set.

Pairs with the seqtoid-web refresh pipeline (verify → load → register → validate → cutover). Next: wire `--min-aupr` into the benchmark CI invocation + the refresh's benchmark step.