### PR TITLE
fix(index-generation): rebuild the image on any index-generation change

### DIFF
--- a/.github/workflows/index-generation-cargo-test.yml
+++ b/.github/workflows/index-generation-cargo-test.yml
@@ -1,9 +1,18 @@
-name: Index Generation NCBI Compress cargo tests
+name: Index Generation image build + NCBI Compress cargo tests
 
+# Builds + publishes the index-generation image AND runs the ncbi-compress cargo tests.
+# The image must be rebuilt whenever ANYTHING under workflows/index-generation changes -- the lineage
+# scripts, requirements.txt (e.g. the numpy==1.23.5 pin), or the Dockerfile -- not only ncbi-compress.
+# The previous trigger (ncbi-compress/** only) meant a lineage-code or requirements change never
+# republished the image, so the ghcr :latest could lag the code (including the pandas/numpy ABI fix)
+# and the quarterly taxonomy refresh would run a stale image. workflow_dispatch allows a manual
+# rebuild. NOTE: the pipeline pulls the VERSIONED image from ECR (<acct>.dkr.ecr...:v<version>); that
+# ECR publish + deploy happens via the release action (Release a WDL workflow -> index-generation).
 on:
   push:
     paths:
-      - 'workflows/index-generation/ncbi-compress/**'
+      - 'workflows/index-generation/**'
+  workflow_dispatch:
 
 env:
   LC_ALL: C.UTF-8


### PR DESCRIPTION
Productionizes the lineage-gen image build. **The bug:** the image build/publish only triggered on `workflows/index-generation/ncbi-compress/**`, so a change to the **lineage scripts or `requirements.txt`** — including the `numpy==1.23.5` pin that fixed the pandas C-ABI break ("index generation is broken") — **never republished the image**. The ghcr `:latest` could lag the code, and the quarterly refresh would run a stale image.

**Fix:** broaden the trigger to `workflows/index-generation/**` + add `workflow_dispatch`. The published image now always reflects current lineage code + the numpy fix.

## The ECR half (operational)
The pipeline pulls the **versioned** image from ECR (`<acct>.dkr.ecr…:v<version>`); that ECR publish + deploy is the **Release a WDL workflow → index-generation** action. So productionization = this trigger fix (image always current) + cutting a versioned index-generation release when the lineage code is ready (documented in the workflow + the taxonomy runbook).